### PR TITLE
Add Prettier integration to ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,12 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import prettierPlugin from "eslint-plugin-prettier";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  prettierPlugin.configs["flat/recommended"],
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
+    "eslint-config-prettier": "^10.0.2",
     "eslint-config-next": "16.1.1",
+    "eslint-plugin-prettier": "^5.2.1",
+    "prettier": "^3.4.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5"


### PR DESCRIPTION
### Motivation
- Align code formatting and linting by integrating Prettier into the existing ESLint setup.
- Ensure ESLint and Prettier do not conflict by using the Prettier recommended configuration for the flat ESLint format.

### Description
- Added Prettier-related dev dependencies to `package.json`: `prettier`, `eslint-config-prettier`, and `eslint-plugin-prettier`.
- Updated `eslint.config.mjs` to import `eslint-plugin-prettier` and extend the config with `prettierPlugin.configs["flat/recommended"]`.
- Kept existing `eslint-config-next` and TypeScript/Next core-vitals configs and preserved custom global ignores in `eslint.config.mjs`.

### Testing
- Attempted `npm install`, which failed due to registry returning `403 Forbidden`, so new dependencies were not installed.
- Reattempts using cleared proxy env and alternate registry (`--registry=https://registry.npmmirror.com`) also failed with `403` responses.
- No automated lint or test commands were successfully run because dependency installation could not complete.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d3964a76c83259072ef1e9d1b00e5)