### PR TITLE
Add Docker Compose and update Docker docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+.gitignore
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+pnpm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Docker
+
+Build the image:
+
+```bash
+docker build -t through-our-eyes .
+```
+
+Run the container:
+
+```bash
+docker run --rm -p 3000:3000 through-our-eyes
+```
+
+Or with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
### Motivation
- Provide an easy local development and run configuration for the containerized web service using Docker Compose.
- Ensure the repository includes the necessary Docker artifacts to build and run the Next.js app consistently (`Dockerfile` and `.dockerignore`).
- Document how to build and run the app with both raw Docker and Docker Compose in the project README.

### Description
- Add `docker-compose.yml` with a `web` service that builds from the project root and publishes port `3000` as `3000:3000`.
- Add a multi-stage `Dockerfile` (deps, builder, runner) that installs dependencies with `npm ci`, builds with `npm run build`, and runs the app with `CMD ["npm", "start"]`.
- Add `.dockerignore` to exclude `node_modules`, `.next`, `.git`, and common npm/yarn/pnpm debug logs from the build context.
- Update `README.md` with commands to build the image (`docker build -t through-our-eyes .`), run the container (`docker run --rm -p 3000:3000 through-our-eyes`), and run with Docker Compose (`docker compose up --build`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db1d8ef60832591f5887e36922dab)