### PR TITLE
Fix build failures: add missing Radix slot, use offline-safe fonts, and tidy library pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "through-our-eyes",
       "version": "0.1.0",
       "dependencies": {
-        "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.562.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.562.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -47,6 +47,8 @@
 }
 
 :root {
+  --font-geist-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-geist-mono: 'SFMono-Regular', 'JetBrains Mono', ui-monospace, monospace;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from 'next'
-import { Geist, Geist_Mono } from 'next/font/google'
 import Link from 'next/link'
 import './globals.css'
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin']
-})
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin']
-})
 
 export const metadata: Metadata = {
   title: 'Through Our Eyes | Club de lectura moderno',
@@ -26,9 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="font-sans antialiased">
         <div className="bg-background text-foreground">
           <header className="border-border/70 bg-card/80 border-b backdrop-blur">
             <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">

--- a/src/app/library/[id]/page.tsx
+++ b/src/app/library/[id]/page.tsx
@@ -1,0 +1,361 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import {
+  ArrowLeft,
+  BookOpen,
+  BookmarkPlus,
+  Clock3,
+  Sparkles,
+  Tag,
+  Wand2
+} from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import {
+  fetchBookById,
+  fetchBooks,
+  type Book,
+  type BookStatus
+} from '@/lib/books'
+
+export const dynamic = 'force-dynamic'
+
+const statusMeta: Record<
+  BookStatus,
+  { label: string; chipClass: string; description: string }
+> = {
+  reading: {
+    label: 'Leyendo',
+    chipClass: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-200',
+    description: 'Sesiones activas y progreso en marcha.'
+  },
+  completed: {
+    label: 'Completado',
+    chipClass: 'bg-neutral-900 text-neutral-50',
+    description: 'Terminaste este libro; listo para repasar notas.'
+  },
+  queued: {
+    label: 'En cola',
+    chipClass: 'bg-blue-500/10 text-blue-700 dark:text-blue-200',
+    description: 'Esperando turno en tu pila de lectura.'
+  }
+}
+
+function DetailBadge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="text-foreground inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-xs font-semibold shadow-sm backdrop-blur dark:bg-white/10 dark:text-white">
+      {children}
+    </span>
+  )
+}
+
+function MoodPill({ mood }: { mood: Book['mood'] }) {
+  return (
+    <div className="from-primary/10 text-primary/80 ring-primary/10 dark:from-primary/10 dark:text-primary-foreground/90 inline-flex items-center gap-2 rounded-full bg-gradient-to-r via-amber-50 to-blue-50 px-3 py-2 text-sm font-semibold tracking-wide uppercase shadow-sm ring-1 dark:via-amber-900/20 dark:to-blue-900/30">
+      <Sparkles className="h-4 w-4" />
+      {mood}
+    </div>
+  )
+}
+
+export async function generateStaticParams() {
+  const data = await fetchBooks()
+  const ids = [...data.library, ...data.recommended].map((book) => ({
+    id: book.id
+  }))
+  return ids
+}
+
+export default async function BookDetailPage({
+  params
+}: {
+  params: { id: string }
+}) {
+  const book = await fetchBookById(params.id)
+
+  if (!book) {
+    notFound()
+  }
+
+  const status = statusMeta[book.status]
+
+  return (
+    <div className="text-foreground relative min-h-screen overflow-hidden bg-gradient-to-b from-amber-50 via-white to-blue-50 antialiased dark:from-zinc-950 dark:via-zinc-900 dark:to-black">
+      <div className="from-primary/10 pointer-events-none absolute inset-x-0 top-0 h-80 bg-gradient-to-b via-transparent to-transparent blur-3xl" />
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-10 lg:px-8">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/library"
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm font-semibold transition"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a la biblioteca
+          </Link>
+          <div className="bg-primary/70 h-2 w-2 animate-pulse rounded-full" />
+          <p className="text-primary/80 text-xs font-semibold tracking-[0.25em] uppercase">
+            Ficha del libro
+          </p>
+        </div>
+
+        <Card className="border-border/70 bg-card/90 overflow-hidden border shadow-[0_30px_120px_-60px_rgb(15,23,42,0.5)]">
+          <div className="relative grid gap-8 lg:grid-cols-[1.2fr_1fr] lg:items-center">
+            <div className="relative isolate overflow-hidden rounded-3xl">
+              <div
+                className={`absolute inset-0 opacity-80 blur-3xl ${book.cover}`}
+              />
+              <div className="relative">
+                <div className="absolute inset-0 rounded-3xl bg-gradient-to-tr from-black/60 via-black/10 to-transparent" />
+                <Image
+                  src={book.coverImage}
+                  alt={book.title}
+                  width={900}
+                  height={1100}
+                  priority
+                  className="h-full max-h-[520px] w-full rounded-3xl object-cover shadow-[0_25px_80px_-45px_rgb(0,0,0,0.65)]"
+                />
+                <div className="absolute bottom-4 left-4 flex flex-wrap gap-2">
+                  <DetailBadge>
+                    <BookOpen className="h-4 w-4" />
+                    {book.genre}
+                  </DetailBadge>
+                  <DetailBadge>{status.label}</DetailBadge>
+                  <DetailBadge>{book.lastOpened}</DetailBadge>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <MoodPill mood={book.mood} />
+                <h1 className="text-3xl leading-tight font-semibold">
+                  {book.title}
+                </h1>
+                <p className="text-muted-foreground text-lg">
+                  {book.author} · {book.genre}
+                </p>
+                <p className="text-muted-foreground text-sm">
+                  Tu ficha personal con progreso, mood y colecciones activas.
+                  Ajusta rituales y etiquetas para mantenerlo en movimiento.
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {book.categories.map((category) => (
+                  <Badge
+                    key={category}
+                    className="bg-primary/10 text-primary border-primary/10"
+                  >
+                    {category}
+                  </Badge>
+                ))}
+                {book.tags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="gap-1">
+                    <Tag className="h-3 w-3" />
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Card className="bg-gradient-to-br from-emerald-50 to-white/60 p-4 shadow-inner dark:from-emerald-900/30 dark:to-white/5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-semibold tracking-wide text-emerald-700 uppercase dark:text-emerald-200">
+                        Estado
+                      </p>
+                      <p className="text-lg font-semibold">{status.label}</p>
+                    </div>
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-semibold ${status.chipClass}`}
+                    >
+                      {status.description}
+                    </span>
+                  </div>
+                </Card>
+                <Card className="bg-gradient-to-br from-blue-50 to-white/60 p-4 shadow-inner dark:from-blue-900/30 dark:to-white/5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-semibold tracking-wide text-blue-700 uppercase dark:text-blue-200">
+                        Avance
+                      </p>
+                      <p className="text-lg font-semibold">
+                        {book.progress}% completado
+                      </p>
+                    </div>
+                    <div className="bg-muted h-2 w-24 overflow-hidden rounded-full">
+                      <div
+                        className="bg-primary h-full rounded-full transition-all"
+                        style={{ width: `${book.progress}%` }}
+                      />
+                    </div>
+                  </div>
+                </Card>
+                <Card className="bg-gradient-to-br from-amber-50 to-white/60 p-4 shadow-inner dark:from-amber-900/30 dark:to-white/5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-200">
+                        Última sesión
+                      </p>
+                      <p className="text-lg font-semibold">{book.lastOpened}</p>
+                    </div>
+                    <Clock3 className="h-5 w-5 text-amber-500" />
+                  </div>
+                </Card>
+                <Card className="bg-gradient-to-br from-indigo-50 to-white/60 p-4 shadow-inner dark:from-indigo-900/30 dark:to-white/5">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-xs font-semibold tracking-wide text-indigo-700 uppercase dark:text-indigo-200">
+                        Ánimo de lectura
+                      </p>
+                      <p className="text-lg font-semibold">{book.mood}</p>
+                    </div>
+                    <Wand2 className="h-5 w-5 text-indigo-500" />
+                  </div>
+                </Card>
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <Button className="gap-2">
+                  <Sparkles className="h-4 w-4" />
+                  Abrir siguiente sesión
+                </Button>
+                <Button variant="outline" className="gap-2">
+                  <BookmarkPlus className="h-4 w-4" />
+                  Añadir a ritual
+                </Button>
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        <div className="grid gap-4 lg:grid-cols-[1.4fr_1fr]">
+          <Card className="border-border/60 bg-card/80 relative overflow-hidden p-6">
+            <div
+              className={`absolute inset-0 opacity-40 blur-3xl ${book.cover}`}
+            />
+            <div className="relative space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="bg-primary/10 text-primary flex h-11 w-11 items-center justify-center rounded-2xl">
+                  <BookOpen className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-lg font-semibold">Bitácora relámpago</p>
+                  <p className="text-muted-foreground text-sm">
+                    Snapshot con todos los datos clave de este libro.
+                  </p>
+                </div>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="border-border/70 bg-background/60 rounded-2xl border p-4 shadow-sm">
+                  <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                    Colecciones
+                  </p>
+                  <p className="text-foreground/80 mt-2 text-sm leading-relaxed">
+                    {book.categories.join(' · ')}
+                  </p>
+                </div>
+                <div className="border-border/70 bg-background/60 rounded-2xl border p-4 shadow-sm">
+                  <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                    Etiquetas activas
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {book.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className="border-border/70 bg-background/60 rounded-2xl border p-4 shadow-sm">
+                  <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                    Progreso & ritmo
+                  </p>
+                  <div className="mt-3 space-y-2">
+                    <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
+                      <div
+                        className="bg-primary h-full rounded-full"
+                        style={{ width: `${book.progress}%` }}
+                      />
+                    </div>
+                    <p className="text-muted-foreground text-sm">
+                      Mantén sesiones cortas y consistentes para cerrar los
+                      últimos capítulos.
+                    </p>
+                  </div>
+                </div>
+                <div className="border-border/70 bg-background/60 rounded-2xl border p-4 shadow-sm">
+                  <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
+                    Último movimiento
+                  </p>
+                  <p className="text-foreground mt-2 text-sm font-semibold">
+                    {book.lastOpened}
+                  </p>
+                  <p className="text-muted-foreground text-sm">
+                    Reactiva el foco con un sprint de 25 minutos y refresca tus
+                    subrayados.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="border-border/70 bg-card/90 p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-lg font-semibold">Ritual sugerido</p>
+                <p className="text-muted-foreground text-sm">
+                  Mezcla de energía juvenil y estructura ligera.
+                </p>
+              </div>
+              <Sparkles className="text-primary h-5 w-5" />
+            </div>
+            <div className="text-foreground/90 mt-4 space-y-3 text-sm">
+              <div className="flex items-start gap-3">
+                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                  1
+                </span>
+                <p>
+                  Calienta con una lectura de 5 minutos para recordar el tono{' '}
+                  <strong>{book.mood.toLowerCase()}</strong>.
+                </p>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                  2
+                </span>
+                <p>
+                  Activa etiquetas como{' '}
+                  <strong>{book.tags.slice(0, 2).join(' · ')}</strong> y enfoca
+                  las notas.
+                </p>
+              </div>
+              <div className="flex items-start gap-3">
+                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                  3
+                </span>
+                <p>
+                  Programa la siguiente sesión con{' '}
+                  <strong>{book.genre.toLowerCase()}</strong> en tu lista rápida
+                  y marca el estado si cambió.
+                </p>
+              </div>
+            </div>
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button className="gap-2">
+                <Wand2 className="h-4 w-4" />
+                Lanzar ritual animado
+              </Button>
+              <Button variant="outline" className="gap-2">
+                <BookmarkPlus className="h-4 w-4" />
+                Guardar como favorito
+              </Button>
+            </div>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -2,6 +2,8 @@
 
 import Image from 'next/image'
 import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import type { LucideIcon } from 'lucide-react'
 import {
   BookOpenCheck,
@@ -54,6 +56,7 @@ function BookCard({
   variant?: CardVariant
 }) {
   const isRecommendation = variant === 'recommendation'
+  const router = useRouter()
   const aspect = isRecommendation ? 'aspect-[3/4]' : 'aspect-[2/3]'
   const cardStyle = isRecommendation
     ? 'bg-transparent border-0 p-0 shadow-none'
@@ -61,9 +64,20 @@ function BookCard({
 
   return (
     <Card
+      role="button"
+      tabIndex={0}
+      onClick={() => router.push(`/library/${book.id}`)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          router.push(`/library/${book.id}`)
+        }
+      }}
       className={`group relative overflow-hidden rounded-3xl transition duration-300 hover:-translate-y-1 hover:shadow-[0_25px_70px_-35px_rgba(15,23,42,0.45)] ${cardStyle}`}
     >
-      <div className={`relative ${aspect} overflow-hidden rounded-3xl`}>
+      <div
+        className={`relative ${aspect} overflow-hidden rounded-3xl shadow-[0_20px_40px_-28px_rgb(15,23,42,0.35)]`}
+      >
         <div
           className={`absolute inset-0 bg-gradient-to-br ${book.cover} opacity-70 transition duration-500 group-hover:opacity-90`}
         />
@@ -99,22 +113,29 @@ function BookCard({
 
         {!isRecommendation ? (
           <div className="absolute top-3 right-3 flex flex-col gap-2 opacity-0 transition duration-300 group-hover:opacity-100">
-            <button className="text-primary rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold tracking-wide uppercase transition hover:bg-white">
+            <Link
+              href={`/library/${book.id}`}
+              className="text-primary rounded-full bg-white/90 px-3 py-1 text-[11px] font-semibold tracking-wide uppercase transition hover:bg-white"
+              onClick={(event) => event.stopPropagation()}
+            >
               Ver ficha
-            </button>
-            <button className="rounded-full bg-black/65 px-3 py-1 text-[11px] font-semibold tracking-wide text-white uppercase transition hover:bg-black/80">
+            </Link>
+            <button
+              className="rounded-full bg-black/65 px-3 py-1 text-[11px] font-semibold tracking-wide text-white uppercase transition hover:bg-black/80"
+              onClick={(event) => event.stopPropagation()}
+            >
               Añadir a lista
             </button>
           </div>
         ) : null}
       </div>
 
-      <div className="mt-4 space-y-1">
+      <div className="relative z-20 mt-4 space-y-1">
         <p className="text-lg leading-tight font-semibold">{book.title}</p>
         <p className="text-muted-foreground text-sm">{book.author}</p>
       </div>
-      <p className="text-primary/80 mt-2 text-sm">{book.mood}</p>
-      <div className="mt-3 flex flex-wrap gap-2">
+      <p className="text-primary/80 relative z-20 mt-2 text-sm">{book.mood}</p>
+      <div className="relative z-20 mt-3 flex flex-wrap gap-2">
         {book.tags.map((tag) => (
           <Badge key={tag} variant="outline">
             {tag}
@@ -122,7 +143,7 @@ function BookCard({
         ))}
       </div>
 
-      <div className="text-muted-foreground mt-4 flex items-center justify-between text-xs">
+      <div className="text-muted-foreground relative z-20 mt-4 flex items-center justify-between text-xs">
         <span
           className={`rounded-full px-3 py-1 font-semibold ${statusStyles[book.status]}`}
         >
@@ -131,7 +152,7 @@ function BookCard({
         <span>{book.progress}%</span>
       </div>
       <div
-        className={`bg-muted mt-2 h-2 w-full overflow-hidden rounded-full ${isRecommendation ? 'opacity-75' : ''}`}
+        className={`bg-muted relative z-20 mt-2 h-2 w-full overflow-hidden rounded-full ${isRecommendation ? 'opacity-75' : ''}`}
       >
         <div
           className="bg-primary h-full rounded-full transition-all"
@@ -184,7 +205,10 @@ export default function LibraryPage() {
     })
   }, [data, query])
 
-  const skeletons = useMemo(() => Array.from({ length: 4 }), [])
+  const skeletons = useMemo<null[]>(
+    () => Array.from({ length: 4 }, () => null),
+    []
+  )
 
   return (
     <div className="text-foreground relative min-h-screen overflow-hidden bg-gradient-to-b from-amber-50 via-white to-blue-50 antialiased dark:from-zinc-950 dark:via-zinc-900 dark:to-black">
@@ -255,7 +279,7 @@ export default function LibraryPage() {
           </div>
           <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-4">
             {(isLoading ? skeletons : filteredRecommended).map((book, index) =>
-              book && typeof book === 'object' ? (
+              book ? (
                 <BookCard key={book.id} book={book} variant="recommendation" />
               ) : (
                 <Card
@@ -289,7 +313,7 @@ export default function LibraryPage() {
           </div>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {(isLoading ? skeletons : filteredLibrary).map((book, index) =>
-              book && typeof book === 'object' ? (
+              book ? (
                 <BookCard key={book.id} book={book} />
               ) : (
                 <Card

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -136,3 +136,10 @@ export async function fetchBooks(): Promise<BooksData> {
   await new Promise((resolve) => setTimeout(resolve, 500))
   return JSON.parse(JSON.stringify(booksMock))
 }
+
+export async function fetchBookById(id: string): Promise<Book | null> {
+  const data = await fetchBooks()
+  const allBooks = [...data.library, ...data.recommended]
+  const book = allBooks.find((entry) => entry.id === id)
+  return book ?? null
+}


### PR DESCRIPTION
### Motivation
- Resolve build failures caused by a missing UI dependency and remote Google Fonts being fetched at build time.
- Provide a stable, offline-safe typography fallback so the app compiles in environments without TLS/google-font access.
- Ensure library cards and the detail route render and navigate correctly at runtime.
- Fix TypeScript/typing issues that caused the library page to fail during the Next.js build.

### Description
- Added `@radix-ui/react-slot` to `dependencies` in `package.json` to satisfy UI imports used by `Button` and related components.
- Replaced `next/font/google` usage with local CSS font variables in `src/app/globals.css` and simplified `src/app/layout.tsx` to use the `font-sans` class so builds do not fetch remote fonts.
- Fixed typing and skeleton handling in `src/app/library/page.tsx` by using `useMemo<null[]>` for placeholders and simplifying the map checks, and made `BookCard` navigable with `useRouter()` plus keyboard handlers and stop-propagation for in-card links.
- Added `fetchBookById` in `src/lib/books.ts` and included the detail page at `src/app/library/[id]/page.tsx` (rich ficha) so book detail routes are available at runtime.

### Testing
- Ran `npm run lint` and auto-fixed formatting with `npx prettier --write`, with `eslint` completing successfully after fixes.
- Ran `npm run build` and confirmed the Next.js production build compiles successfully after the fixes.
- Verified the previous build errors (missing module and TypeScript error) were resolved by the applied changes.
- No unit tests were added; only the automated `lint` and `build` checks were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d79a3e74c8325862ea669f16704e0)