### PR TITLE
Simplificar subida de libros: foco en metadata, soporte multi-archivo y quitar vista previa EPUB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1619,7 +1618,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1679,7 +1677,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2179,7 +2176,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2466,7 +2462,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2531,7 +2526,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3120,7 +3114,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3221,7 +3214,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3323,7 +3315,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5501,7 +5492,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5660,7 +5650,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5670,7 +5659,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6385,7 +6373,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6558,7 +6545,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6834,7 +6820,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -231,9 +231,11 @@ export default function LibraryPage() {
                 <Filter className="h-4 w-4" />
                 Filtros rápidos
               </Button>
-              <Button className="gap-2">
-                <Sparkles className="h-4 w-4" />
-                Añadir libro
+              <Button asChild className="gap-2">
+                <Link href="/library/upload">
+                  <Sparkles className="h-4 w-4" />
+                  Añadir libro
+                </Link>
               </Button>
             </div>
           </div>

--- a/src/app/library/upload/page.tsx
+++ b/src/app/library/upload/page.tsx
@@ -1,0 +1,325 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, FileText, FileUp, Plus, UploadCloud } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { fetchUserLists, type UserList } from '@/lib/lists'
+
+type SupportedFormat = 'pdf' | 'epub' | 'other'
+
+type UploadItem = {
+  id: string
+  file: File
+  title: string
+  author: string
+  language: string
+  year: string
+  tags: string
+  description: string
+  listId: string
+  format: SupportedFormat
+}
+
+const supportedFormats = ['PDF', 'EPUB', 'MOBI', 'AZW3', 'TXT']
+
+const getFileFormat = (file: File): SupportedFormat => {
+  const extension = file.name.split('.').pop()?.toLowerCase()
+  if (file.type === 'application/pdf' || extension === 'pdf') {
+    return 'pdf'
+  }
+  if (file.type === 'application/epub+zip' || extension === 'epub') {
+    return 'epub'
+  }
+  return 'other'
+}
+
+const formatFileSize = (bytes: number) => {
+  if (!bytes) return '0 KB'
+  const kb = bytes / 1024
+  if (kb < 1024) return `${kb.toFixed(1)} KB`
+  return `${(kb / 1024).toFixed(1)} MB`
+}
+
+const createUploadItem = (file: File): UploadItem => ({
+  id: crypto.randomUUID(),
+  file,
+  title: file.name.replace(/\.[^/.]+$/, ''),
+  author: '',
+  language: 'Español',
+  year: '',
+  tags: '',
+  description: '',
+  listId: '',
+  format: getFileFormat(file)
+})
+
+export default function UploadBookPage() {
+  const [uploads, setUploads] = useState<UploadItem[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const [lists, setLists] = useState<UserList[]>([])
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    let mounted = true
+    fetchUserLists().then((data) => {
+      if (!mounted) return
+      setLists(data)
+    })
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  const activeUpload = useMemo(
+    () => uploads.find((upload) => upload.id === activeId) ?? uploads[0],
+    [uploads, activeId]
+  )
+
+  const handleFiles = (fileList: FileList | null) => {
+    if (!fileList?.length) return
+    const newItems = Array.from(fileList).map((file) => createUploadItem(file))
+    setUploads((prev) => [...prev, ...newItems])
+    setActiveId(newItems[0]?.id ?? null)
+  }
+
+  const updateUpload = (id: string, updates: Partial<UploadItem>) => {
+    setUploads((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, ...updates } : item))
+    )
+  }
+
+  return (
+    <div className="text-foreground relative min-h-screen overflow-hidden bg-gradient-to-b from-amber-50 via-white to-blue-50 antialiased dark:from-zinc-950 dark:via-zinc-900 dark:to-black">
+      <div className="from-primary/10 pointer-events-none absolute inset-x-0 top-0 h-48 bg-gradient-to-b via-transparent to-transparent blur-3xl" />
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10 lg:px-8">
+        <div className="flex items-center gap-3">
+          <Link
+            href="/library"
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm font-semibold transition"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a la biblioteca
+          </Link>
+          <div className="bg-primary/70 h-2 w-2 animate-pulse rounded-full" />
+          <p className="text-primary/80 text-xs font-semibold tracking-[0.25em] uppercase">
+            Subir libros
+          </p>
+        </div>
+
+        <header className="border-border/70 bg-card/90 flex flex-col gap-3 rounded-3xl border p-6 shadow-sm backdrop-blur">
+          <div className="space-y-2">
+            <h1 className="text-2xl leading-tight font-semibold">
+              Gestiona la metadata antes de guardar.
+            </h1>
+            <p className="text-muted-foreground text-sm">
+              Sube uno o varios archivos y completa los datos clave de cada
+              libro.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {supportedFormats.map((format) => (
+              <Badge key={format} variant="outline">
+                {format}
+              </Badge>
+            ))}
+          </div>
+        </header>
+
+        <Card className="border-border/70 bg-card/90 p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex items-center gap-3">
+              <div className="bg-primary/10 text-primary flex h-10 w-10 items-center justify-center rounded-2xl">
+                <UploadCloud className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-base font-semibold">Carga múltiple</p>
+                <p className="text-muted-foreground text-sm">
+                  Arrastra varios archivos o selecciónalos desde tu equipo.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Input
+                ref={inputRef}
+                type="file"
+                accept=".pdf,.epub,.mobi,.azw3,.txt"
+                multiple
+                className="hidden"
+                onChange={(event) => handleFiles(event.target.files)}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => inputRef.current?.click()}
+                className="gap-2"
+              >
+                <FileText className="h-4 w-4" />
+                Seleccionar archivos
+              </Button>
+            </div>
+          </div>
+          <div
+            className="border-border/70 bg-muted/40 mt-5 flex min-h-[120px] items-center justify-center rounded-3xl border border-dashed text-sm text-muted-foreground"
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={(event) => {
+              event.preventDefault()
+              handleFiles(event.dataTransfer.files)
+            }}
+          >
+            <div className="flex items-center gap-2">
+              <FileUp className="h-4 w-4" />
+              Suelta tus libros aquí
+            </div>
+          </div>
+        </Card>
+
+        <div className="grid gap-6 lg:grid-cols-[0.7fr_1.3fr]">
+          <Card className="border-border/70 bg-card/90 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-base font-semibold">Archivos cargados</p>
+              <Badge variant="outline">{uploads.length} libros</Badge>
+            </div>
+            <div className="mt-4 space-y-2">
+              {uploads.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  Aún no has cargado archivos.
+                </p>
+              ) : (
+                uploads.map((upload) => (
+                  <button
+                    key={upload.id}
+                    onClick={() => setActiveId(upload.id)}
+                    className={`flex w-full items-center justify-between rounded-2xl border px-3 py-2 text-left text-sm transition ${
+                      upload.id === activeUpload?.id
+                        ? 'border-primary/50 bg-primary/5 text-foreground'
+                        : 'border-border/70 text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    <span className="font-semibold">{upload.title || 'Sin título'}</span>
+                    <span className="text-xs uppercase">
+                      {upload.format === 'other' ? 'OTRO' : upload.format}
+                    </span>
+                  </button>
+                ))
+              )}
+            </div>
+          </Card>
+
+          <Card className="border-border/70 bg-card/90 p-6 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-base font-semibold">Metadata del libro</p>
+              <Button variant="outline" className="gap-2">
+                <Plus className="h-4 w-4" />
+                Nueva lista
+              </Button>
+            </div>
+
+            {!activeUpload ? (
+              <div className="text-muted-foreground mt-6 text-sm">
+                Selecciona un archivo para editar su metadata.
+              </div>
+            ) : (
+              <div className="mt-6 grid gap-4">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label className="space-y-2 text-sm font-semibold">
+                    Título
+                    <Input
+                      value={activeUpload.title}
+                      onChange={(event) =>
+                        updateUpload(activeUpload.id, {
+                          title: event.target.value
+                        })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-2 text-sm font-semibold">
+                    Autor/a
+                    <Input
+                      value={activeUpload.author}
+                      onChange={(event) =>
+                        updateUpload(activeUpload.id, {
+                          author: event.target.value
+                        })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-2 text-sm font-semibold">
+                    Idioma
+                    <Input
+                      value={activeUpload.language}
+                      onChange={(event) =>
+                        updateUpload(activeUpload.id, {
+                          language: event.target.value
+                        })
+                      }
+                    />
+                  </label>
+                  <label className="space-y-2 text-sm font-semibold">
+                    Año de publicación
+                    <Input
+                      value={activeUpload.year}
+                      onChange={(event) =>
+                        updateUpload(activeUpload.id, { year: event.target.value })
+                      }
+                    />
+                  </label>
+                </div>
+
+                <label className="space-y-2 text-sm font-semibold">
+                  Etiquetas (separa con comas)
+                  <Input
+                    value={activeUpload.tags}
+                    onChange={(event) =>
+                      updateUpload(activeUpload.id, { tags: event.target.value })
+                    }
+                  />
+                </label>
+
+                <label className="space-y-2 text-sm font-semibold">
+                  Descripción
+                  <textarea
+                    value={activeUpload.description}
+                    onChange={(event) =>
+                      updateUpload(activeUpload.id, {
+                        description: event.target.value
+                      })
+                    }
+                    className="border-input bg-background focus-visible:ring-ring/80 min-h-[110px] w-full rounded-2xl border px-4 py-3 text-sm shadow-none focus-visible:outline-none focus-visible:ring-2"
+                  />
+                </label>
+
+                <label className="space-y-2 text-sm font-semibold">
+                  Añadir a lista de lectura
+                  <select
+                    value={activeUpload.listId}
+                    onChange={(event) =>
+                      updateUpload(activeUpload.id, { listId: event.target.value })
+                    }
+                    className="border-input bg-background focus-visible:ring-ring/80 w-full rounded-2xl border px-4 py-3 text-sm shadow-none focus-visible:outline-none focus-visible:ring-2"
+                  >
+                    <option value="">Selecciona una lista</option>
+                    {lists.map((list) => (
+                      <option key={list.id} value={list.id}>
+                        {list.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <div className="text-muted-foreground text-xs">
+                  {activeUpload.file.name} ·{' '}
+                  {formatFileSize(activeUpload.file.size)}
+                </div>
+              </div>
+            )}
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Hacer la vista de subida más minimalista y centrada en la edición de metadata antes de guardar los libros. 
- Permitir subir varios archivos a la vez y elegir cuál editar como activo. 
- Integrar la selección de lista de lectura por libro como parte del flujo de subida. 
- Evitar integrar ahora la vista previa de EPUB para mantener la implementación simple y seguir mejores prácticas.

### Description
- Reescribe la página de subida en `src/app/library/upload/page.tsx` para soportar carga múltiple, selección de archivo activo y edición de metadata (título, autor, idioma, año, etiquetas, descripción y asignación a lista). 
- Añade consulta a `fetchUserLists` (`src/lib/lists.ts`) y permite seleccionar la lista de lectura para cada libro cargado. 
- Elimina la lógica de previsualización EPUB y la dependencia asociada, simplificando `package.json` y `package-lock.json`. 
- Actualiza el CTA en `src/app/library/page.tsx` para que el botón "Añadir libro" enlace a `/library/upload` usando `Button asChild` y `Link`.

### Testing
- Se ejecutó `npm uninstall epubjs` y la desinstalación finalizó con éxito (0 vulnerabilidades detectadas). 
- Se arranca el servidor de desarrollo con `npm run dev -- --hostname 0.0.0.0 --port 3000` y la ruta `/library/upload` respondió `GET 200` tras la compilación. 
- Se capturó una captura automática con Playwright visitando `http://127.0.0.1:3000/library/upload` y se generó el artefacto `artifacts/library-upload-minimal.png`. 
- No se reportaron errores de compilación durante las pruebas de desarrollo mencionadas arriba.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd2cd59f08325895b1a73b5c8b005)