### PR TITLE
Add richer external book detail view (synopsis, editorial info, ratings & comments)

### DIFF
--- a/src/app/library/[id]/page.tsx
+++ b/src/app/library/[id]/page.tsx
@@ -6,11 +6,16 @@ import {
   BookOpen,
   BookmarkPlus,
   Clock3,
+  Globe,
+  MessageSquare,
   LayoutList,
   ListPlus,
   Plus,
+  Share2,
   Sparkles,
+  Star,
   Tag,
+  User,
   Wand2
 } from 'lucide-react'
 
@@ -142,9 +147,11 @@ export default async function BookDetailPage({
                 <p className="text-muted-foreground text-lg">
                   {book.author} · {book.genre}
                 </p>
-                <p className="text-muted-foreground text-sm">
-                  Tu ficha personal con progreso, mood y colecciones activas.
-                  Ajusta rituales y etiquetas para mantenerlo en movimiento.
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  {book.synopsis}
+                </p>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  {book.professionalDescription}
                 </p>
               </div>
 
@@ -236,6 +243,10 @@ export default async function BookDetailPage({
                   <ListPlus className="h-4 w-4" />
                   Añadir a mi lista
                 </Button>
+                <Button variant="ghost" className="gap-2">
+                  <Share2 className="h-4 w-4" />
+                  Compartir
+                </Button>
               </div>
             </div>
           </div>
@@ -315,48 +326,69 @@ export default async function BookDetailPage({
           <Card className="border-border/70 bg-card/90 p-6">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-lg font-semibold">Ritual sugerido</p>
+                <p className="text-lg font-semibold">Ficha editorial</p>
                 <p className="text-muted-foreground text-sm">
-                  Mezcla de energía juvenil y estructura ligera.
+                  Información bibliográfica y detalles de publicación.
                 </p>
               </div>
-              <Sparkles className="text-primary h-5 w-5" />
+              <BookOpen className="text-primary h-5 w-5" />
             </div>
-            <div className="text-foreground/90 mt-4 space-y-3 text-sm">
-              <div className="flex items-start gap-3">
-                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
-                  1
+            <div className="mt-5 grid gap-3 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Autor
                 </span>
-                <p>
-                  Calienta con una lectura de 5 minutos para recordar el tono{' '}
-                  <strong>{book.mood.toLowerCase()}</strong>.
-                </p>
+                <span className="font-semibold">{book.author}</span>
               </div>
-              <div className="flex items-start gap-3">
-                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
-                  2
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Traductor
                 </span>
-                <p>
-                  Activa etiquetas como{' '}
-                  <strong>{book.tags.slice(0, 2).join(' · ')}</strong> y enfoca
-                  las notas.
-                </p>
+                <span className="font-semibold">{book.translator}</span>
               </div>
-              <div className="flex items-start gap-3">
-                <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
-                  3
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Editorial
                 </span>
-                <p>
-                  Programa la siguiente sesión con{' '}
-                  <strong>{book.genre.toLowerCase()}</strong> en tu lista rápida
-                  y marca el estado si cambió.
-                </p>
+                <span className="font-semibold">{book.publisher}</span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Año
+                </span>
+                <span className="font-semibold">{book.publicationYear}</span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Idioma
+                </span>
+                <span className="font-semibold">{book.language}</span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Páginas
+                </span>
+                <span className="font-semibold">{book.pages}</span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  Edición
+                </span>
+                <span className="font-semibold">{book.edition}</span>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
+                <span className="text-muted-foreground text-xs font-semibold uppercase">
+                  ISBN
+                </span>
+                <span className="font-semibold">{book.isbn}</span>
               </div>
             </div>
             <div className="mt-6 flex flex-wrap gap-2">
-              <Button className="gap-2">
-                <Wand2 className="h-4 w-4" />
-                Lanzar ritual animado
+              <Button asChild className="gap-2">
+                <Link href={book.purchaseLink} target="_blank" rel="noreferrer">
+                  <Globe className="h-4 w-4" />
+                  Comprar en Busca Libre
+                </Link>
               </Button>
               <Button variant="outline" className="gap-2">
                 <BookmarkPlus className="h-4 w-4" />
@@ -413,23 +445,31 @@ export default async function BookDetailPage({
           <Card className="border-border/70 bg-card/90 p-6">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <p className="text-lg font-semibold">Agrega a mi lista</p>
+                <p className="text-lg font-semibold">Sección del autor</p>
                 <p className="text-muted-foreground text-sm">
-                  Crea una nueva lista o ajusta la visibilidad para compartir
-                  recomendaciones.
+                  Perfil breve del autor y sus líneas temáticas.
                 </p>
               </div>
-              <LayoutList className="text-primary h-5 w-5" />
+              <User className="text-primary h-5 w-5" />
             </div>
-            <div className="mt-6 space-y-4">
+            <p className="text-muted-foreground mt-4 text-sm leading-relaxed">
+              {book.authorSection}
+            </p>
+            <div className="mt-6 space-y-3">
               <div className="border-border/70 bg-background/60 rounded-2xl border p-4">
                 <p className="text-muted-foreground text-xs font-semibold tracking-wide uppercase">
-                  Nombre sugerido
+                  Categorías del autor
                 </p>
-                <p className="text-base font-semibold">Lecturas que brillan</p>
-                <p className="text-muted-foreground mt-2 text-sm">
-                  Agrupa historias con energía similar y añade notas rápidas.
-                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {book.categories.map((category) => (
+                    <Badge
+                      key={`author-${category}`}
+                      className="bg-primary/10 text-primary border-primary/10"
+                    >
+                      {category}
+                    </Badge>
+                  ))}
+                </div>
               </div>
               <div className="flex flex-col gap-2">
                 <Button className="gap-2">
@@ -444,6 +484,166 @@ export default async function BookDetailPage({
             </div>
           </Card>
         </div>
+
+        <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+          <Card className="border-border/70 bg-card/90 p-6">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-lg font-semibold">Libros similares</p>
+                <p className="text-muted-foreground text-sm">
+                  Títulos recomendados con temática o estilo afín.
+                </p>
+              </div>
+              <Sparkles className="text-primary h-5 w-5" />
+            </div>
+            <div className="mt-5 grid gap-3">
+              {book.similarBooks.map((similar) => (
+                <div
+                  key={`${similar.title}-${similar.author}`}
+                  className="border-border/70 bg-background/60 flex flex-wrap items-center justify-between gap-4 rounded-2xl border p-4 shadow-sm"
+                >
+                  <div>
+                    <p className="text-base font-semibold">{similar.title}</p>
+                    <p className="text-muted-foreground text-sm">
+                      {similar.author}
+                    </p>
+                  </div>
+                  <Button variant="outline" className="gap-2">
+                    <BookOpen className="h-4 w-4" />
+                    Ver ficha
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card className="border-border/70 bg-card/90 p-6">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-lg font-semibold">Calificaciones</p>
+                <p className="text-muted-foreground text-sm">
+                  {book.ratings.total} reseñas · promedio {book.ratings.average}
+                </p>
+              </div>
+              <Star className="text-primary h-5 w-5" />
+            </div>
+            <div className="mt-4 space-y-3">
+              {book.ratings.breakdown.map((item) => (
+                <div key={item.label} className="space-y-2">
+                  <div className="flex items-center justify-between text-xs font-semibold uppercase text-muted-foreground">
+                    <span>{item.label}</span>
+                    <span>{item.count}</span>
+                  </div>
+                  <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
+                    <div
+                      className="bg-primary h-full rounded-full"
+                      style={{
+                        width: `${Math.round(
+                          (item.count / book.ratings.total) * 100
+                        )}%`
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </div>
+
+        <Card className="border-border/70 bg-card/90 p-6">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-lg font-semibold">Comentarios</p>
+              <p className="text-muted-foreground text-sm">
+                Opiniones recientes de lectores.
+              </p>
+            </div>
+            <MessageSquare className="text-primary h-5 w-5" />
+          </div>
+          <div className="mt-5 grid gap-4 md:grid-cols-2">
+            {book.ratings.comments.map((comment) => (
+              <div
+                key={comment.id}
+                className="border-border/70 bg-background/60 rounded-2xl border p-4 shadow-sm"
+              >
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold">{comment.name}</p>
+                  <span className="text-muted-foreground text-xs">
+                    {comment.date}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center gap-1 text-amber-500">
+                  {Array.from({ length: 5 }).map((_, index) => (
+                    <Star
+                      key={`${comment.id}-star-${index}`}
+                      className={`h-4 w-4 ${
+                        index < comment.rating
+                          ? 'fill-amber-400'
+                          : 'fill-transparent text-muted-foreground/40'
+                      }`}
+                    />
+                  ))}
+                </div>
+                <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+                  {comment.comment}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <Card className="border-border/70 bg-card/90 p-6">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-1">
+              <p className="text-lg font-semibold">Ritual sugerido</p>
+              <p className="text-muted-foreground text-sm">
+                Mezcla de energía juvenil y estructura ligera.
+              </p>
+            </div>
+            <Wand2 className="text-primary h-5 w-5" />
+          </div>
+          <div className="text-foreground/90 mt-4 space-y-3 text-sm">
+            <div className="flex items-start gap-3">
+              <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                1
+              </span>
+              <p>
+                Calienta con una lectura de 5 minutos para recordar el tono{' '}
+                <strong>{book.mood.toLowerCase()}</strong>.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                2
+              </span>
+              <p>
+                Activa etiquetas como{' '}
+                <strong>{book.tags.slice(0, 2).join(' · ')}</strong> y enfoca las
+                notas.
+              </p>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="bg-primary/10 text-primary mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold">
+                3
+              </span>
+              <p>
+                Programa la siguiente sesión con{' '}
+                <strong>{book.genre.toLowerCase()}</strong> en tu lista rápida y
+                marca el estado si cambió.
+              </p>
+            </div>
+          </div>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Button className="gap-2">
+              <Wand2 className="h-4 w-4" />
+              Lanzar ritual animado
+            </Button>
+            <Button variant="outline" className="gap-2">
+              <BookmarkPlus className="h-4 w-4" />
+              Guardar como favorito
+            </Button>
+          </div>
+        </Card>
       </div>
     </div>
   )

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -13,6 +13,30 @@ export interface Book {
   cover: string
   coverImage: string
   lastOpened: string
+  synopsis: string
+  professionalDescription: string
+  purchaseLink: string
+  isbn: string
+  translator: string
+  publisher: string
+  publicationYear: number
+  language: string
+  pages: number
+  edition: string
+  authorSection: string
+  similarBooks: Array<{ title: string; author: string }>
+  ratings: {
+    average: number
+    total: number
+    breakdown: Array<{ label: string; count: number }>
+    comments: Array<{
+      id: string
+      name: string
+      rating: number
+      date: string
+      comment: string
+    }>
+  }
 }
 
 export interface BooksData {
@@ -35,7 +59,55 @@ const booksMock: BooksData = {
       cover: 'from-rose-100 via-amber-50 to-white',
       coverImage:
         'https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Recomendado hoy'
+      lastOpened: 'Recomendado hoy',
+      synopsis:
+        'Una carta abierta al duelo que entrelaza memorias personales con la historia de Marie Curie y el arte de recomponerse.',
+      professionalDescription:
+        'Ensayo narrativo de corte autobiográfico que combina investigación y memoria para retratar la resiliencia femenina en la cultura europea.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-la-ridicula-idea-de-no-volver-a-verte/9788432220804/p/46647176',
+      isbn: '978-84-322-2080-4',
+      translator: 'No aplica',
+      publisher: 'Seix Barral',
+      publicationYear: 2013,
+      language: 'Español',
+      pages: 240,
+      edition: '1ª edición',
+      authorSection:
+        'Rosa Montero es periodista y escritora española; su obra mezcla narrativa, ensayo y perfiles biográficos con una mirada íntima sobre la experiencia humana.',
+      similarBooks: [
+        { title: 'El año del pensamiento mágico', author: 'Joan Didion' },
+        { title: 'La ridícula idea de no volver a verte (Club de lectura)', author: 'Rosa Montero' }
+      ],
+      ratings: {
+        average: 4.6,
+        total: 1284,
+        breakdown: [
+          { label: '5 estrellas', count: 860 },
+          { label: '4 estrellas', count: 300 },
+          { label: '3 estrellas', count: 92 },
+          { label: '2 estrellas', count: 22 },
+          { label: '1 estrella', count: 10 }
+        ],
+        comments: [
+          {
+            id: 'rec-1-comment-1',
+            name: 'María P.',
+            rating: 5,
+            date: 'Feb 2024',
+            comment:
+              'Una lectura conmovedora que equilibra memoria y divulgación sin perder sensibilidad.'
+          },
+          {
+            id: 'rec-1-comment-2',
+            name: 'Jorge L.',
+            rating: 4,
+            date: 'Ene 2024',
+            comment:
+              'Me gustó el enfoque documental; la mezcla con Marie Curie es fascinante.'
+          }
+        ]
+      }
     },
     {
       id: 'rec-2',
@@ -50,7 +122,55 @@ const booksMock: BooksData = {
       cover: 'from-indigo-100 via-blue-100 to-cyan-50',
       coverImage:
         'https://images.unsplash.com/photo-1463320726281-696a485928c7?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Basado en tus notas de sci-fi'
+      lastOpened: 'Basado en tus notas de sci-fi',
+      synopsis:
+        'Un científico despierta solo en una misión espacial con un objetivo imposible: salvar a la Tierra de la extinción.',
+      professionalDescription:
+        'Thriller de ciencia ficción dura con énfasis en resolución de problemas y ritmo cinematográfico, premiado por su narrativa accesible.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-project-hail-mary/9780593135204/p/53078960',
+      isbn: '978-0-593-13520-4',
+      translator: 'Javier Guerrero',
+      publisher: 'Ballantine Books',
+      publicationYear: 2021,
+      language: 'Inglés',
+      pages: 496,
+      edition: '1ª edición',
+      authorSection:
+        'Andy Weir es autor de ciencia ficción con formación en ingeniería; sus novelas destacan por el rigor científico y el humor técnico.',
+      similarBooks: [
+        { title: 'The Martian', author: 'Andy Weir' },
+        { title: 'Artemis', author: 'Andy Weir' }
+      ],
+      ratings: {
+        average: 4.8,
+        total: 2140,
+        breakdown: [
+          { label: '5 estrellas', count: 1700 },
+          { label: '4 estrellas', count: 340 },
+          { label: '3 estrellas', count: 80 },
+          { label: '2 estrellas', count: 15 },
+          { label: '1 estrella', count: 5 }
+        ],
+        comments: [
+          {
+            id: 'rec-2-comment-1',
+            name: 'Lucas R.',
+            rating: 5,
+            date: 'Mar 2024',
+            comment:
+              'Ciencia ficción divertida y emotiva; no podía soltarlo.'
+          },
+          {
+            id: 'rec-2-comment-2',
+            name: 'Elena V.',
+            rating: 4,
+            date: 'Feb 2024',
+            comment:
+              'Mucho detalle científico, pero el corazón de la historia lo compensa.'
+          }
+        ]
+      }
     }
   ],
   library: [
@@ -67,7 +187,55 @@ const booksMock: BooksData = {
       cover: 'from-amber-200 via-amber-100 to-white',
       coverImage:
         'https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Ayer'
+      lastOpened: 'Ayer',
+      synopsis:
+        'Un recorrido por la historia del libro y la lectura desde la Antigüedad hasta el mundo moderno.',
+      professionalDescription:
+        'Ensayo literario de alta divulgación que combina investigación histórica con estilo narrativo y sensibilidad poética.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-el-infinito-en-un-junco/9788417860794/p/50668265',
+      isbn: '978-84-17860-79-4',
+      translator: 'No aplica',
+      publisher: 'Siruela',
+      publicationYear: 2019,
+      language: 'Español',
+      pages: 452,
+      edition: '1ª edición',
+      authorSection:
+        'Irene Vallejo es filóloga y ensayista; su obra explora la tradición clásica y la historia cultural con un tono narrativo cercano.',
+      similarBooks: [
+        { title: 'La biblioteca perdida', author: 'David M. Rubenstein' },
+        { title: 'Los libros y la libertad', author: 'Luis Rodríguez' }
+      ],
+      ratings: {
+        average: 4.7,
+        total: 1876,
+        breakdown: [
+          { label: '5 estrellas', count: 1300 },
+          { label: '4 estrellas', count: 430 },
+          { label: '3 estrellas', count: 110 },
+          { label: '2 estrellas', count: 24 },
+          { label: '1 estrella', count: 12 }
+        ],
+        comments: [
+          {
+            id: 'book-1-comment-1',
+            name: 'Paula M.',
+            rating: 5,
+            date: 'Mar 2024',
+            comment:
+              'Una carta de amor a los libros. Me dejó con ganas de releer clásicos.'
+          },
+          {
+            id: 'book-1-comment-2',
+            name: 'Diego S.',
+            rating: 4,
+            date: 'Feb 2024',
+            comment:
+              'Muy informativo y a la vez poético. Ideal para amantes de la lectura.'
+          }
+        ]
+      }
     },
     {
       id: 'book-2',
@@ -82,7 +250,55 @@ const booksMock: BooksData = {
       cover: 'from-emerald-200 via-emerald-100 to-white',
       coverImage:
         'https://images.unsplash.com/photo-1496104679561-38b3b4d7d00d?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Hace 2 días'
+      lastOpened: 'Hace 2 días',
+      synopsis:
+        'Guía práctica para construir hábitos sostenibles mediante cambios pequeños y consistentes.',
+      professionalDescription:
+        'Manual de autoayuda con base en ciencia del comportamiento, enfocado en sistemas y procesos diarios.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-habitos-atomicos/9788479539042/p/50971732',
+      isbn: '978-84-7953-904-2',
+      translator: 'Jorge Pizarro',
+      publisher: 'Paidós',
+      publicationYear: 2018,
+      language: 'Español',
+      pages: 328,
+      edition: '1ª edición',
+      authorSection:
+        'James Clear es escritor y conferencista especializado en hábitos, rendimiento y toma de decisiones; mantiene un boletín sobre mejora continua.',
+      similarBooks: [
+        { title: 'El poder de los hábitos', author: 'Charles Duhigg' },
+        { title: 'Essentialism', author: 'Greg McKeown' }
+      ],
+      ratings: {
+        average: 4.5,
+        total: 2450,
+        breakdown: [
+          { label: '5 estrellas', count: 1600 },
+          { label: '4 estrellas', count: 620 },
+          { label: '3 estrellas', count: 180 },
+          { label: '2 estrellas', count: 35 },
+          { label: '1 estrella', count: 15 }
+        ],
+        comments: [
+          {
+            id: 'book-2-comment-1',
+            name: 'Laura B.',
+            rating: 5,
+            date: 'Ene 2024',
+            comment:
+              'Súper claro y aplicable; ya tengo nuevas rutinas.'
+          },
+          {
+            id: 'book-2-comment-2',
+            name: 'Mateo G.',
+            rating: 4,
+            date: 'Dic 2023',
+            comment:
+              'Repite algunas ideas, pero en general es muy útil.'
+          }
+        ]
+      }
     },
     {
       id: 'book-3',
@@ -97,7 +313,54 @@ const booksMock: BooksData = {
       cover: 'from-slate-200 via-slate-100 to-white',
       coverImage:
         'https://images.unsplash.com/photo-1463320726281-696a485928c7?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Semana pasada'
+      lastOpened: 'Semana pasada',
+      synopsis:
+        'Una síntesis provocadora de la historia de la humanidad desde los primeros Homo sapiens hasta la actualidad.',
+      professionalDescription:
+        'Ensayo histórico con enfoque interdisciplinario que combina antropología, economía y cultura en un relato accesible.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-sapiens-de-animales-a-dioses/9788499924213/p/48638631',
+      isbn: '978-84-9992-421-3',
+      translator: 'Joandomènec Ros',
+      publisher: 'Debate',
+      publicationYear: 2014,
+      language: 'Español',
+      pages: 496,
+      edition: '1ª edición',
+      authorSection:
+        'Yuval Noah Harari es historiador y profesor; sus obras exploran el impacto de la tecnología, la biología y la cultura en la humanidad.',
+      similarBooks: [
+        { title: 'Homo Deus', author: 'Yuval Noah Harari' },
+        { title: 'Guns, Germs, and Steel', author: 'Jared Diamond' }
+      ],
+      ratings: {
+        average: 4.4,
+        total: 3100,
+        breakdown: [
+          { label: '5 estrellas', count: 1800 },
+          { label: '4 estrellas', count: 860 },
+          { label: '3 estrellas', count: 300 },
+          { label: '2 estrellas', count: 90 },
+          { label: '1 estrella', count: 50 }
+        ],
+        comments: [
+          {
+            id: 'book-3-comment-1',
+            name: 'Sofía C.',
+            rating: 5,
+            date: 'Nov 2023',
+            comment:
+              'Me cambió la forma de ver la historia; muy recomendable.'
+          },
+          {
+            id: 'book-3-comment-2',
+            name: 'Andrés R.',
+            rating: 4,
+            date: 'Oct 2023',
+            comment: 'Excelente síntesis, aunque algunas partes se hacen densas.'
+          }
+        ]
+      }
     },
     {
       id: 'book-4',
@@ -112,7 +375,53 @@ const booksMock: BooksData = {
       cover: 'from-sky-100 via-white to-amber-50',
       coverImage:
         'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'En cola'
+      lastOpened: 'En cola',
+      synopsis:
+        'En una cafetería de Tokio, los clientes pueden viajar en el tiempo bajo reglas estrictas que revelan el valor del presente.',
+      professionalDescription:
+        'Novela breve con estructura episódica y tono melancólico, ideal para lectores de ficción introspectiva.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-before-the-coffee-gets-cold/9781526611120/p/50995732',
+      isbn: '978-1-5266-1112-0',
+      translator: 'Geoffrey Trousselot',
+      publisher: 'Picador',
+      publicationYear: 2015,
+      language: 'Inglés',
+      pages: 213,
+      edition: '1ª edición',
+      authorSection:
+        'Toshikazu Kawaguchi es dramaturgo y novelista japonés; su obra se centra en la nostalgia y las segundas oportunidades.',
+      similarBooks: [
+        { title: 'Sweet Bean Paste', author: 'Durian Sukegawa' },
+        { title: 'The Cat and the City', author: 'Nick Bradley' }
+      ],
+      ratings: {
+        average: 4.2,
+        total: 980,
+        breakdown: [
+          { label: '5 estrellas', count: 500 },
+          { label: '4 estrellas', count: 300 },
+          { label: '3 estrellas', count: 130 },
+          { label: '2 estrellas', count: 30 },
+          { label: '1 estrella', count: 20 }
+        ],
+        comments: [
+          {
+            id: 'book-4-comment-1',
+            name: 'Nina A.',
+            rating: 4,
+            date: 'Sep 2023',
+            comment: 'Corta y emotiva, perfecta para una tarde tranquila.'
+          },
+          {
+            id: 'book-4-comment-2',
+            name: 'Carlos D.',
+            rating: 4,
+            date: 'Ago 2023',
+            comment: 'Historias sencillas con mucha carga emocional.'
+          }
+        ]
+      }
     },
     {
       id: 'book-5',
@@ -127,7 +436,53 @@ const booksMock: BooksData = {
       cover: 'from-neutral-200 via-neutral-100 to-white',
       coverImage:
         'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=800&q=80',
-      lastOpened: 'Hace 3 semanas'
+      lastOpened: 'Hace 3 semanas',
+      synopsis:
+        'Ensayo crítico sobre la autoexplotación y el agotamiento en la sociedad contemporánea.',
+      professionalDescription:
+        'Filosofía contemporánea con estilo breve y contundente, centrada en la cultura del rendimiento.',
+      purchaseLink:
+        'https://www.buscalibre.com.co/libro-la-sociedad-del-cansancio/9788425435980/p/46850039',
+      isbn: '978-84-254-3598-0',
+      translator: 'Alberto Ciria',
+      publisher: 'Herder',
+      publicationYear: 2012,
+      language: 'Español',
+      pages: 128,
+      edition: '1ª edición',
+      authorSection:
+        'Byung-Chul Han es filósofo y ensayista; sus textos cuestionan la cultura digital, el rendimiento y la subjetividad.',
+      similarBooks: [
+        { title: 'Psicopolítica', author: 'Byung-Chul Han' },
+        { title: 'La sociedad de la transparencia', author: 'Byung-Chul Han' }
+      ],
+      ratings: {
+        average: 4.1,
+        total: 760,
+        breakdown: [
+          { label: '5 estrellas', count: 330 },
+          { label: '4 estrellas', count: 260 },
+          { label: '3 estrellas', count: 120 },
+          { label: '2 estrellas', count: 30 },
+          { label: '1 estrella', count: 20 }
+        ],
+        comments: [
+          {
+            id: 'book-5-comment-1',
+            name: 'Rocío T.',
+            rating: 5,
+            date: 'Jun 2023',
+            comment: 'Breve pero demoledor; te deja pensando.'
+          },
+          {
+            id: 'book-5-comment-2',
+            name: 'Iván M.',
+            rating: 3,
+            date: 'May 2023',
+            comment: 'Interesante, aunque me habría gustado más desarrollo.'
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Provide a comprehensive external book detail page that surfaces cover, synopsis, professional description, purchase link, ISBN and full bibliographic metadata. 
- Show author information, allow adding to lists and sharing, and surface similar titles and reader ratings/comments. 
- Extend the mocked book dataset so the UI has realistic editorial, purchase and ratings data. 
- Keep the existing reading/collection features while enhancing the public-facing book card.

### Description
- Expanded the `Book` model in `src/lib/books.ts` with fields like `synopsis`, `professionalDescription`, `purchaseLink`, `isbn`, `translator`, `publisher`, `publicationYear`, `language`, `pages`, `edition`, `authorSection`, `similarBooks` and `ratings`, and populated the `booksMock` entries accordingly. 
- Reworked the book detail UI in `src/app/library/[id]/page.tsx` to display synopsis and professional description, an editorial card with bibliographic fields and a buy button linking to `book.purchaseLink` (now using `rel="noreferrer"`), an author section, similar books list, ratings breakdown and comments, plus share and action buttons. 
- Added new icon imports from `lucide-react` and updated several UI blocks while preserving previous features such as progress, mood pill, badges and lists. 
- Modified only `src/lib/books.ts` and `src/app/library/[id]/page.tsx` (updated and committed).

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which launched Next.js but the page render produced a compile error due to a missing module `@radix-ui/react-slot`. 
- Executed a Playwright script to navigate to `/library/book-1` and capture a screenshot artifact, which completed and saved `artifacts/book-detail.png` despite the runtime compilation issue. 
- The page request returned a 500 because of the compile failure referencing `@radix-ui/react-slot`, so the new page could not fully render in the running dev environment. 
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ddcb2d3c08325830245a2486a7b0c)