### PR TITLE
Replace Radix Slot with local helper and add author pages/components

### DIFF
--- a/src/app/authors/[slug]/page.tsx
+++ b/src/app/authors/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import { notFound } from 'next/navigation'
+
+import AuthorDetail from '@/components/author/author-detail'
+import { fetchAuthorBySlug, fetchAuthorSlugs } from '@/lib/authors'
+
+export async function generateStaticParams() {
+  return fetchAuthorSlugs()
+}
+
+export default async function AuthorPage({
+  params
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const author = await fetchAuthorBySlug(slug)
+
+  if (!author) {
+    notFound()
+  }
+
+  return <AuthorDetail author={author} />
+}

--- a/src/app/library/[id]/page.tsx
+++ b/src/app/library/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   type Book,
   type BookStatus
 } from '@/lib/books'
+import { getAuthorSlug } from '@/lib/authors'
 import { fetchUserLists } from '@/lib/lists'
 
 export const dynamic = 'force-dynamic'
@@ -145,7 +146,13 @@ export default async function BookDetailPage({
                   {book.title}
                 </h1>
                 <p className="text-muted-foreground text-lg">
-                  {book.author} · {book.genre}
+                  <Link
+                    href={`/authors/${getAuthorSlug(book.author)}`}
+                    className="text-foreground transition hover:text-primary"
+                  >
+                    {book.author}
+                  </Link>{' '}
+                  · {book.genre}
                 </p>
                 <p className="text-muted-foreground text-sm leading-relaxed">
                   {book.synopsis}
@@ -340,7 +347,12 @@ export default async function BookDetailPage({
                 <span className="text-muted-foreground text-xs font-semibold uppercase">
                   Autor
                 </span>
-                <span className="font-semibold">{book.author}</span>
+                <Link
+                  href={`/authors/${getAuthorSlug(book.author)}`}
+                  className="font-semibold transition hover:text-primary"
+                >
+                  {book.author}
+                </Link>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2 rounded-2xl border border-white/10 bg-background/60 px-4 py-3">
                 <span className="text-muted-foreground text-xs font-semibold uppercase">

--- a/src/components/author/author-detail.tsx
+++ b/src/components/author/author-detail.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import {
+  ArrowLeft,
+  BookOpen,
+  LayoutList,
+  Share2,
+  Sparkles,
+  User
+} from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import type { AuthorDetail } from '@/lib/authors'
+
+const sortLabels = {
+  relevance: 'Relevancia',
+  publication: 'Orden de salida'
+} as const
+
+type SortOption = keyof typeof sortLabels
+
+type AuthorDetailProps = {
+  author: AuthorDetail
+}
+
+export default function AuthorDetail({ author }: AuthorDetailProps) {
+  const [sort, setSort] = useState<SortOption>('relevance')
+  const [activeSaga, setActiveSaga] = useState(author.sagas[0]?.id ?? '')
+
+  const sortedBooks = useMemo(() => {
+    if (sort === 'publication') {
+      return [...author.books].sort(
+        (a, b) => a.publicationYear - b.publicationYear
+      )
+    }
+
+    return author.books
+  }, [author.books, sort])
+
+  const saga = author.sagas.find((item) => item.id === activeSaga)
+
+  return (
+    <div className="text-foreground relative min-h-screen overflow-hidden bg-gradient-to-b from-amber-50 via-white to-blue-50 antialiased dark:from-zinc-950 dark:via-zinc-900 dark:to-black">
+      <div className="from-primary/10 pointer-events-none absolute inset-x-0 top-0 h-80 bg-gradient-to-b via-transparent to-transparent blur-3xl" />
+      <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-10 lg:px-8">
+        <div className="flex items-center justify-between gap-4">
+          <Link
+            href="/library"
+            className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm font-semibold transition"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a la biblioteca
+          </Link>
+          <Button variant="outline" className="gap-2">
+            <Share2 className="h-4 w-4" />
+            Compartir autor
+          </Button>
+        </div>
+
+        <Card className="border-border/70 bg-card/90 overflow-hidden border shadow-[0_30px_120px_-60px_rgb(15,23,42,0.5)]">
+          <div className="grid gap-8 p-6 lg:grid-cols-[1.1fr_1fr] lg:items-center">
+            <div className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="bg-primary/10 text-primary flex h-11 w-11 items-center justify-center rounded-2xl">
+                  <User className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="text-primary/80 text-xs font-semibold tracking-[0.3em] uppercase">
+                    Perfil del autor
+                  </p>
+                  <h1 className="text-3xl font-semibold leading-tight">
+                    {author.profile.name}
+                  </h1>
+                </div>
+              </div>
+              <p className="text-muted-foreground text-sm leading-relaxed">
+                {author.profile.bio}
+              </p>
+              <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-sm">
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 font-semibold shadow-sm dark:bg-white/10">
+                  {author.profile.location}
+                </span>
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 font-semibold shadow-sm dark:bg-white/10">
+                  {author.totalBooks} libros publicados
+                </span>
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/70 px-3 py-1 font-semibold shadow-sm dark:bg-white/10">
+                  {author.earliestYear} · {author.latestYear}
+                </span>
+              </div>
+              <p className="text-foreground/90 text-sm italic">
+                {author.profile.quote}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {author.categories.map((category) => (
+                  <Badge
+                    key={category}
+                    className="bg-primary/10 text-primary border-primary/10"
+                  >
+                    {category}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            <div className="relative isolate">
+              <div className="absolute inset-0 rounded-3xl bg-gradient-to-tr from-black/50 via-black/10 to-transparent" />
+              <Image
+                src={author.profile.image}
+                alt={author.profile.name}
+                width={900}
+                height={900}
+                className="h-full max-h-[420px] w-full rounded-3xl object-cover shadow-[0_25px_80px_-45px_rgb(0,0,0,0.65)]"
+              />
+            </div>
+          </div>
+        </Card>
+
+        <Card className="border-border/70 bg-card/90 p-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-lg font-semibold">Libros del autor</p>
+              <p className="text-muted-foreground text-sm">
+                Lista completa con ordenación por relevancia o salida.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-muted-foreground text-xs font-semibold uppercase">
+                Ordenar por
+              </span>
+              {Object.entries(sortLabels).map(([value, label]) => (
+                <Button
+                  key={value}
+                  variant={sort === value ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setSort(value as SortOption)}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+          <div
+            id="all-books"
+            className="mt-5 grid gap-4 md:grid-cols-2"
+          >
+            {sortedBooks.map((book, index) => (
+              <div
+                key={book.id}
+                className="border-border/70 bg-background/60 flex gap-4 rounded-2xl border p-4 shadow-sm"
+              >
+                <div className="relative h-24 w-20 overflow-hidden rounded-2xl">
+                  <Image
+                    src={book.coverImage}
+                    alt={book.title}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+                <div className="flex flex-1 flex-col justify-between">
+                  <div>
+                    <p className="text-xs font-semibold uppercase text-muted-foreground">
+                      {sort === 'publication' ? index + 1 : book.publicationYear}
+                    </p>
+                    <p className="text-base font-semibold">{book.title}</p>
+                    <p className="text-muted-foreground text-sm">
+                      {book.genre} · {book.publicationYear}
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-muted-foreground line-clamp-2 text-xs">
+                      {book.synopsis}
+                    </p>
+                    <Button size="sm" variant="outline" className="gap-2">
+                      <BookOpen className="h-4 w-4" />
+                      Ver ficha
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <Card className="border-border/70 bg-card/90 p-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-lg font-semibold">Sagas destacadas</p>
+              <p className="text-muted-foreground text-sm">
+                Elige una saga para explorar una selección breve.
+              </p>
+            </div>
+            <Button asChild variant="outline" className="gap-2">
+              <Link href="#all-books">
+                <LayoutList className="h-4 w-4" />
+                Ver todos los libros
+              </Link>
+            </Button>
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            {author.sagas.map((sagaOption) => (
+              <Button
+                key={sagaOption.id}
+                size="sm"
+                variant={activeSaga === sagaOption.id ? 'default' : 'outline'}
+                onClick={() => setActiveSaga(sagaOption.id)}
+              >
+                {sagaOption.name}
+              </Button>
+            ))}
+          </div>
+
+          {saga && (
+            <div className="mt-6 space-y-3">
+              <div className="flex items-center gap-2 text-sm">
+                <Sparkles className="text-primary h-4 w-4" />
+                <p className="font-semibold">{saga.description}</p>
+              </div>
+              <div className="flex gap-4 overflow-x-auto pb-4">
+                {saga.items.map((item) => (
+                  <div
+                    key={`${saga.id}-${item.title}`}
+                    className="border-border/70 bg-background/60 w-64 flex-none rounded-2xl border p-4 shadow-sm"
+                  >
+                    <div className="relative h-36 w-full overflow-hidden rounded-2xl">
+                      <Image
+                        src={item.coverImage}
+                        alt={item.title}
+                        fill
+                        className="object-cover"
+                      />
+                    </div>
+                    <div className="mt-3 space-y-1">
+                      <p className="text-xs font-semibold uppercase text-muted-foreground">
+                        {item.year}
+                      </p>
+                      <p className="text-base font-semibold">{item.title}</p>
+                      <p className="text-muted-foreground text-xs">
+                        {item.note}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
+
+function Slot({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLElement> & { children: React.ReactElement }) {
+  return React.cloneElement(children, {
+    ...props,
+    className: cn(props.className, children.props.className)
+  })
+}
 
 const buttonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/80 disabled:pointer-events-none disabled:opacity-50',

--- a/src/lib/authors.ts
+++ b/src/lib/authors.ts
@@ -1,0 +1,264 @@
+import { fetchBooks, type Book } from '@/lib/books'
+
+export interface AuthorBookSummary {
+  id: string
+  title: string
+  genre: string
+  coverImage: string
+  publicationYear: number
+  synopsis: string
+}
+
+export interface AuthorSagaItem {
+  title: string
+  year: number
+  coverImage: string
+  note: string
+}
+
+export interface AuthorSaga {
+  id: string
+  name: string
+  description: string
+  items: AuthorSagaItem[]
+}
+
+export interface AuthorProfile {
+  name: string
+  slug: string
+  bio: string
+  image: string
+  quote: string
+  location: string
+}
+
+export interface AuthorDetail {
+  profile: AuthorProfile
+  categories: string[]
+  books: AuthorBookSummary[]
+  totalBooks: number
+  earliestYear: number
+  latestYear: number
+  sagas: AuthorSaga[]
+}
+
+const authorProfiles: Record<string, Omit<AuthorProfile, 'slug'>> = {
+  'irene-vallejo': {
+    name: 'Irene Vallejo',
+    bio: 'Filóloga y ensayista que rescata la memoria de los libros con un tono narrativo cercano. Sus textos combinan investigación, divulgación cultural y un fuerte pulso poético.',
+    image:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=900&q=80',
+    quote: '"Escribir es construir un refugio para la curiosidad."',
+    location: 'Zaragoza, España'
+  },
+  'rosa-montero': {
+    name: 'Rosa Montero',
+    bio: 'Periodista y novelista que entrelaza experiencia personal, historia y ficción. Su obra explora la vulnerabilidad, el duelo y la resiliencia con voz íntima.',
+    image:
+      'https://images.unsplash.com/photo-1526510747491-58f928ec870f?auto=format&fit=crop&w=900&q=80',
+    quote: '"La literatura es la gran conversación con la vida."',
+    location: 'Madrid, España'
+  },
+  'andy-weir': {
+    name: 'Andy Weir',
+    bio: 'Autor de ciencia ficción dura con formación en ingeniería, conocido por historias optimistas y un sentido del humor técnico que equilibra tensión y asombro.',
+    image:
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=900&q=80',
+    quote: '"Resolver problemas imposibles es mi deporte favorito."',
+    location: 'California, EE.UU.'
+  }
+}
+
+const authorSagas: Record<string, AuthorSaga[]> = {
+  'irene-vallejo': [
+    {
+      id: 'tradicion-clasica',
+      name: 'Tradición clásica',
+      description: 'Ensayos sobre el legado grecolatino y su eco en la lectura contemporánea.',
+      items: [
+        {
+          title: 'El infinito en un junco',
+          year: 2019,
+          coverImage:
+            'https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&w=800&q=80',
+          note: 'Bitácora histórica sobre el libro y sus guardianes.'
+        },
+        {
+          title: 'Manuscritos de viento',
+          year: 2021,
+          coverImage:
+            'https://images.unsplash.com/photo-1495446815901-a7297e633e8d?auto=format&fit=crop&w=800&q=80',
+          note: 'Crónica de bibliotecas nómadas y lectores viajeros.'
+        },
+        {
+          title: 'Voces del papiro',
+          year: 2023,
+          coverImage:
+            'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=800&q=80',
+          note: 'Retratos breves de autoras clásicas olvidadas.'
+        }
+      ]
+    },
+    {
+      id: 'mapa-lectoras',
+      name: 'Mapa de lectoras',
+      description: 'Relatos cortos para clubes de lectura y conversación comunitaria.',
+      items: [
+        {
+          title: 'Cartas a la lectura',
+          year: 2018,
+          coverImage:
+            'https://images.unsplash.com/photo-1457694587812-e8bf29a43845?auto=format&fit=crop&w=800&q=80',
+          note: 'Epistolario sobre hábitos de lectura.'
+        },
+        {
+          title: 'Bitácora del aula',
+          year: 2020,
+          coverImage:
+            'https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&w=800&q=80',
+          note: 'Experiencias docentes en talleres literarios.'
+        }
+      ]
+    }
+  ],
+  'rosa-montero': [
+    {
+      id: 'memoria-viva',
+      name: 'Memoria viva',
+      description: 'Serie de no ficción sobre duelo, biografía y resiliencia.',
+      items: [
+        {
+          title: 'La ridícula idea de no volver a verte',
+          year: 2013,
+          coverImage:
+            'https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=800&q=80',
+          note: 'Ensayo personal con el legado de Marie Curie.'
+        },
+        {
+          title: 'El peligro de estar cuerda',
+          year: 2022,
+          coverImage:
+            'https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=800&q=80',
+          note: 'Reflexión sobre creatividad y salud mental.'
+        }
+      ]
+    }
+  ],
+  'andy-weir': [
+    {
+      id: 'misiones-imposibles',
+      name: 'Misiones imposibles',
+      description: 'Ciencia ficción optimista centrada en ciencia aplicada.',
+      items: [
+        {
+          title: 'Project Hail Mary',
+          year: 2021,
+          coverImage:
+            'https://images.unsplash.com/photo-1463320726281-696a485928c7?auto=format&fit=crop&w=800&q=80',
+          note: 'Un profesor convertido en héroe espacial.'
+        },
+        {
+          title: 'The Martian',
+          year: 2014,
+          coverImage:
+            'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=800&q=80',
+          note: 'Sobrevivir en Marte con ingenio y humor.'
+        }
+      ]
+    }
+  ]
+}
+
+const defaultSaga = (books: AuthorBookSummary[]): AuthorSaga[] => [
+  {
+    id: 'seleccion-curada',
+    name: 'Selección curada',
+    description: 'Un vistazo breve a títulos representativos de esta autora o autor.',
+    items: books.slice(0, 3).map((book) => ({
+      title: book.title,
+      year: book.publicationYear,
+      coverImage: book.coverImage,
+      note: book.synopsis
+    }))
+  }
+]
+
+export function getAuthorSlug(name: string) {
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+}
+
+function getProfile(name: string, slug: string): AuthorProfile {
+  const profile = authorProfiles[slug]
+  if (profile) {
+    return { ...profile, slug }
+  }
+
+  return {
+    name,
+    slug,
+    bio: 'Autor destacado dentro de la biblioteca, con obras que conectan con distintos públicos y estilos narrativos.',
+    image:
+      'https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=900&q=80',
+    quote: '"Cada libro es un puente entre épocas y lectores."',
+    location: 'Latinoamérica'
+  }
+}
+
+function mapBookSummary(book: Book): AuthorBookSummary {
+  return {
+    id: book.id,
+    title: book.title,
+    genre: book.genre,
+    coverImage: book.coverImage,
+    publicationYear: book.publicationYear,
+    synopsis: book.synopsis
+  }
+}
+
+export async function fetchAuthorBySlug(
+  slug: string
+): Promise<AuthorDetail | null> {
+  const data = await fetchBooks()
+  const books = [...data.library, ...data.recommended].filter(
+    (book) => getAuthorSlug(book.author) === slug
+  )
+
+  if (books.length === 0) {
+    return null
+  }
+
+  const mappedBooks = books.map(mapBookSummary)
+  const categories = Array.from(
+    new Set(books.flatMap((book) => book.categories))
+  )
+  const years = books.map((book) => book.publicationYear)
+  const earliestYear = Math.min(...years)
+  const latestYear = Math.max(...years)
+  const profile = getProfile(books[0].author, slug)
+  const sagas = authorSagas[slug] ?? defaultSaga(mappedBooks)
+
+  return {
+    profile,
+    categories,
+    books: mappedBooks,
+    totalBooks: books.length,
+    earliestYear,
+    latestYear,
+    sagas
+  }
+}
+
+export async function fetchAuthorSlugs() {
+  const data = await fetchBooks()
+  const slugs = new Set(
+    [...data.library, ...data.recommended].map((book) =>
+      getAuthorSlug(book.author)
+    )
+  )
+  return Array.from(slugs).map((slug) => ({ slug }))
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated author view (profile, categories, book list and sagas) and enable navigation from book detail to an author page.
- Add library helpers and types to generate author slugs and fetch author data for static params and rendering.
- Fix a build failure caused by a missing `@radix-ui/react-slot` dependency that prevented the server from compiling.
- Use a lightweight local `Slot` helper to avoid the external Radix dependency and improve portability.

### Description

- Add `src/lib/authors.ts` with author types and helpers including `getAuthorSlug`, `fetchAuthorBySlug`, and `fetchAuthorSlugs`.
- Add a client author component at `src/components/author/author-detail.tsx` that renders profile, book list, and sagas.
- Add the author route `src/app/authors/[slug]/page.tsx` and update `src/app/library/[id]/page.tsx` to link author names via `getAuthorSlug`.
- Remove the `@radix-ui/react-slot` import and implement a local `Slot` helper inside `src/components/ui/button.tsx` to support `asChild` usage.

### Testing

- Starting the dev server before the fix failed with a missing module error for `@radix-ui/react-slot` (build error) — failed.
- A Playwright run that attempted to open `/authors/irene-vallejo` produced a 500 response due to the server compile failure — failed.
- No automated unit or integration test suites were executed after the fix — not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de1f3bba08325b8c4d6dcc1d1ce05)