### PR TITLE
Add SOLID-style books API routes

### DIFF
--- a/src/app/api/books/[id]/route.ts
+++ b/src/app/api/books/[id]/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from 'next/server'
+
+import { bookRepository } from '../repository'
+import { BookService } from '../service'
+import { NotFoundError, ValidationError } from '../errors'
+
+const service = new BookService(bookRepository)
+
+type RouteContext = {
+  params: {
+    id: string
+  }
+}
+
+export async function GET(_: Request, context: RouteContext) {
+  try {
+    const book = await service.getBookById(context.params.id)
+
+    return NextResponse.json({ data: book })
+  } catch (error) {
+    return handleServiceError(error)
+  }
+}
+
+export async function PUT(request: Request, context: RouteContext) {
+  try {
+    const payload = await request.json()
+    const book = await service.updateBook(context.params.id, payload)
+
+    return NextResponse.json({ data: book })
+  } catch (error) {
+    return handleServiceError(error)
+  }
+}
+
+export async function DELETE(_: Request, context: RouteContext) {
+  try {
+    await service.deleteBook(context.params.id)
+
+    return NextResponse.json({ data: { id: context.params.id } })
+  } catch (error) {
+    return handleServiceError(error)
+  }
+}
+
+function handleServiceError(error: unknown) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.statusCode }
+    )
+  }
+
+  return NextResponse.json(
+    { error: 'Ocurrió un error inesperado en la API.' },
+    { status: 500 }
+  )
+}

--- a/src/app/api/books/errors.ts
+++ b/src/app/api/books/errors.ts
@@ -1,0 +1,17 @@
+export class ValidationError extends Error {
+  readonly statusCode = 400
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+export class NotFoundError extends Error {
+  readonly statusCode = 404
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}

--- a/src/app/api/books/repository.ts
+++ b/src/app/api/books/repository.ts
@@ -1,0 +1,88 @@
+import type { Book, CreateBookInput, UpdateBookInput } from './types'
+
+export interface BookRepository {
+  list(): Promise<Book[]>
+  getById(id: string): Promise<Book | null>
+  create(input: CreateBookInput): Promise<Book>
+  update(id: string, input: UpdateBookInput): Promise<Book | null>
+  remove(id: string): Promise<boolean>
+}
+
+const initialBooks: Book[] = [
+  {
+    id: 'bk-001',
+    title: 'La ciudad y los perros',
+    author: 'Mario Vargas Llosa',
+    summary: 'Un retrato intenso de la adolescencia y el poder.',
+    status: 'published',
+    createdAt: new Date('2024-01-12T10:00:00.000Z').toISOString(),
+    updatedAt: new Date('2024-01-12T10:00:00.000Z').toISOString()
+  },
+  {
+    id: 'bk-002',
+    title: 'Distancia de rescate',
+    author: 'Samanta Schweblin',
+    summary: 'Una historia sobre maternidad, miedo y vínculos.',
+    status: 'draft',
+    createdAt: new Date('2024-02-03T15:30:00.000Z').toISOString(),
+    updatedAt: new Date('2024-02-03T15:30:00.000Z').toISOString()
+  }
+]
+
+class InMemoryBookRepository implements BookRepository {
+  private readonly store = new Map<string, Book>()
+
+  constructor(seed: Book[]) {
+    seed.forEach((book) => this.store.set(book.id, book))
+  }
+
+  async list(): Promise<Book[]> {
+    return Array.from(this.store.values())
+  }
+
+  async getById(id: string): Promise<Book | null> {
+    return this.store.get(id) ?? null
+  }
+
+  async create(input: CreateBookInput): Promise<Book> {
+    const now = new Date().toISOString()
+    const book: Book = {
+      id: `bk-${crypto.randomUUID()}`,
+      title: input.title,
+      author: input.author,
+      summary: input.summary,
+      status: input.status ?? 'draft',
+      createdAt: now,
+      updatedAt: now
+    }
+
+    this.store.set(book.id, book)
+
+    return book
+  }
+
+  async update(id: string, input: UpdateBookInput): Promise<Book | null> {
+    const existing = this.store.get(id)
+
+    if (!existing) {
+      return null
+    }
+
+    const updated: Book = {
+      ...existing,
+      ...input,
+      updatedAt: new Date().toISOString()
+    }
+
+    this.store.set(id, updated)
+
+    return updated
+  }
+
+  async remove(id: string): Promise<boolean> {
+    return this.store.delete(id)
+  }
+}
+
+export const bookRepository: BookRepository =
+  new InMemoryBookRepository(initialBooks)

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server'
+
+import { bookRepository } from './repository'
+import { BookService } from './service'
+import { NotFoundError, ValidationError } from './errors'
+
+const service = new BookService(bookRepository)
+
+export async function GET() {
+  const books = await service.listBooks()
+
+  return NextResponse.json({ data: books })
+}
+
+export async function POST(request: Request) {
+  try {
+    const payload = await request.json()
+    const book = await service.createBook(payload)
+
+    return NextResponse.json({ data: book }, { status: 201 })
+  } catch (error) {
+    return handleServiceError(error)
+  }
+}
+
+function handleServiceError(error: unknown) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.statusCode }
+    )
+  }
+
+  return NextResponse.json(
+    { error: 'Ocurrió un error inesperado en la API.' },
+    { status: 500 }
+  )
+}

--- a/src/app/api/books/service.ts
+++ b/src/app/api/books/service.ts
@@ -1,0 +1,80 @@
+import { NotFoundError, ValidationError } from './errors'
+import type { Book, CreateBookInput, UpdateBookInput } from './types'
+import type { BookRepository } from './repository'
+
+const ALLOWED_STATUSES: Book['status'][] = ['draft', 'published']
+
+export class BookService {
+  constructor(private readonly repository: BookRepository) {}
+
+  async listBooks(): Promise<Book[]> {
+    return this.repository.list()
+  }
+
+  async getBookById(id: string): Promise<Book> {
+    const book = await this.repository.getById(id)
+
+    if (!book) {
+      throw new NotFoundError('El libro solicitado no existe.')
+    }
+
+    return book
+  }
+
+  async createBook(input: CreateBookInput): Promise<Book> {
+    this.validateCreateInput(input)
+
+    return this.repository.create({
+      ...input,
+      status: input.status ?? 'draft'
+    })
+  }
+
+  async updateBook(id: string, input: UpdateBookInput): Promise<Book> {
+    this.validateUpdateInput(input)
+
+    const updated = await this.repository.update(id, input)
+
+    if (!updated) {
+      throw new NotFoundError('No encontramos el libro para actualizar.')
+    }
+
+    return updated
+  }
+
+  async deleteBook(id: string): Promise<void> {
+    const removed = await this.repository.remove(id)
+
+    if (!removed) {
+      throw new NotFoundError('No encontramos el libro para eliminar.')
+    }
+  }
+
+  private validateCreateInput(input: CreateBookInput) {
+    if (!input.title?.trim()) {
+      throw new ValidationError('El título es obligatorio.')
+    }
+
+    if (!input.author?.trim()) {
+      throw new ValidationError('El autor es obligatorio.')
+    }
+
+    if (input.status && !ALLOWED_STATUSES.includes(input.status)) {
+      throw new ValidationError('El estado del libro no es válido.')
+    }
+  }
+
+  private validateUpdateInput(input: UpdateBookInput) {
+    if (input.title !== undefined && !input.title.trim()) {
+      throw new ValidationError('El título no puede estar vacío.')
+    }
+
+    if (input.author !== undefined && !input.author.trim()) {
+      throw new ValidationError('El autor no puede estar vacío.')
+    }
+
+    if (input.status && !ALLOWED_STATUSES.includes(input.status)) {
+      throw new ValidationError('El estado del libro no es válido.')
+    }
+  }
+}

--- a/src/app/api/books/types.ts
+++ b/src/app/api/books/types.ts
@@ -1,0 +1,22 @@
+export type BookStatus = 'draft' | 'published'
+
+export type Book = {
+  id: string
+  title: string
+  author: string
+  summary?: string
+  status: BookStatus
+  createdAt: string
+  updatedAt: string
+}
+
+export type CreateBookInput = {
+  title: string
+  author: string
+  summary?: string
+  status?: BookStatus
+}
+
+export type UpdateBookInput = Partial<Omit<CreateBookInput, 'status'>> & {
+  status?: BookStatus
+}


### PR DESCRIPTION
### Motivation
- Provide a SOLID-patterned example CRUD API for books under `src/app/api/books` to demonstrate good Next.js App Router server API practices.
- Separate concerns into typed domain models, repository, service, and HTTP route handlers to keep business logic decoupled from transport.
- Offer an in-memory repository and explicit error types to make example usage and error handling deterministic and easy to follow.
- Ensure route handlers return consistent JSON responses and map domain errors to appropriate HTTP status codes.

### Description
- Added domain types in `src/app/api/books/types.ts` defining `Book`, `CreateBookInput`, and `UpdateBookInput`.
- Implemented `ValidationError` and `NotFoundError` in `src/app/api/books/errors.ts` for consistent error semantics.
- Implemented an in-memory `BookRepository` in `src/app/api/books/repository.ts` and a `BookService` in `src/app/api/books/service.ts` that contains validation and business logic.
- Implemented collection and item route handlers in `src/app/api/books/route.ts` and `src/app/api/books/[id]/route.ts` using `NextResponse` and a shared `handleServiceError` mapping domain errors to HTTP responses.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef06f9fe88325b3a16931bc8bc509)